### PR TITLE
use ws^8.18.0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsquid/squid-types",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "description": "JS and TS types relating to 0xsquid related projects.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
@@ -42,7 +42,8 @@
   "dependencies": {
     "@axelar-network/axelarjs-sdk": "^0.16.1",
     "@ethersproject/providers": "^5.7.2",
-    "typescript": "*"
+    "typescript": "*",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2767,6 +2767,11 @@ ws@^8.13.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.15.1.tgz#271ba33a45ca0cc477940f7f200cd7fba7ee1997"
   integrity sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==
 
+ws@^8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
 ws@~8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"


### PR DESCRIPTION
# Description of changes

override the ws transitive dependency version to use the latest version

- closes ticket #

# Check specifically for:

WRITE_HERE
