### PR TITLE
Remove unused squid-types exports (ISS-1386)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsquid/squid-types",
-  "version": "0.1.232",
+  "version": "0.1.233",
   "description": "JS and TS types relating to 0xsquid related projects.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -418,12 +418,6 @@ export type Channel = {
   };
 };
 
-export type IbcData = {
-  chain_1: ChainIBCInfo;
-  chain_2: ChainIBCInfo;
-  channels: Channel[];
-};
-
 export enum CosmosChainFeatures {
   PACKET_FORWARD_MIDDLEWARE = "packet-forward-middleware",
   LEGACY_IBC = "legacy-ibc",

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -5,10 +5,6 @@ export type SquidError = {
   path?: string;
 };
 
-export type SquidErrorResponse = {
-  errors: SquidError[];
-};
-
 export enum ErrorType {
   SCHEMA_VALIDATION_ERROR = "SCHEMA_VALIDATION_ERROR",
   PATH_FINDER_ERROR = "PATH_FINDER_ERROR",

--- a/src/featureFlag/index.ts
+++ b/src/featureFlag/index.ts
@@ -16,6 +16,7 @@ export enum FeatureFlagType {
   BypassCompliance = "bypassCompliance",
   Ripple = "ripple",
   RippleCoralV2 = "rippleCoralV2",
+  Megabridge = "megabridge",
   Stellar = "stellar",
   StellarCoralV2 = "stellarCoralV2",
   Mantra = "mantra",

--- a/src/featureFlag/index.ts
+++ b/src/featureFlag/index.ts
@@ -16,7 +16,6 @@ export enum FeatureFlagType {
   BypassCompliance = "bypassCompliance",
   Ripple = "ripple",
   RippleCoralV2 = "rippleCoralV2",
-  Megabridge = "megabridge",
   Stellar = "stellar",
   StellarCoralV2 = "stellarCoralV2",
   Mantra = "mantra",

--- a/src/tokens/index.ts
+++ b/src/tokens/index.ts
@@ -22,21 +22,6 @@ export interface Token {
   tokenProgramId?: string;
 }
 
-export interface CosmosToken extends Token {
-  denom: string;
-  base_denom: string;
-  base_type: string;
-  dp_denom: string;
-  origin_chain: string;
-  decimal: number;
-  description: string;
-  image: string;
-}
-
-export interface EvmToken extends Token {
-  address: string;
-}
-
 export enum Volatility {
   SUPER_STABLE,
   STABLE,


### PR DESCRIPTION
Removes unused published symbols from squid-types (ISS-1386).

Removed:
- `CosmosToken` interface (`src/tokens/index.ts`)
- `EvmToken` interface (`src/tokens/index.ts`)
- `IbcData` type (`src/chains/index.ts`)
- `SquidErrorResponse` type (`src/errors/index.ts`)

Patch version bump: 0.1.232 -> 0.1.233. No internal usages; tsc, lint, and build all clean.
