### PR TITLE
Add GIWA_SEPOLIA network identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsquid/squid-types",
-  "version": "0.1.234",
+  "version": "0.1.235",
   "description": "JS and TS types relating to 0xsquid related projects.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -392,6 +392,7 @@ export enum NetworkIdentifier {
   XRPL_EVM_TESTNET = "xrpl-evm-testnet",
 
   STELLAR_TESTNET = "stellar-testnet",
+  GIWA_SEPOLIA = "giwa-sepolia",
 }
 
 export type ChainIBCInfo = {


### PR DESCRIPTION
Adds `GIWA_SEPOLIA` to `NetworkIdentifier`. Required by the Giwa L1 inclusion-fee branch in squid-api, which switches on this enum.

Ticket: [ISS-1603 — Support Giwa Testnet for Upbit](https://app.notion.com/p/squidrouter/Support-Giwa-Testnet-for-Upbit-3a648876f67c80b3a867e4779dcc7849)
